### PR TITLE
fix(cli): update ReadManager to allow absolute filepaths

### DIFF
--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -38,6 +38,7 @@ class DocumentRequest(BaseModel):
             configuration for the splitting method.
         metadata (Optional[List[str]]): Additional metadata for the document.
     """
+
     document_name: Optional[str] = None
     document_path: str
     document_id: Optional[str] = None
@@ -61,6 +62,7 @@ class ChunkResponse(BaseModel):
         metadata (Optional[List[str]]): Additional metadata for the document.
         ocr_method (OCRMethodEnum): The OCR method used for processing images in the document.
     """
+
     chunks: List[str]
     chunk_id: List[str]
     chunk_path: str

--- a/src/application/api/routers/split.py
+++ b/src/application/api/routers/split.py
@@ -47,7 +47,8 @@ async def split_document(
         ..., description="Method to split the document text."
     ),
     ocr_method: OCRMethodEnum = Form(
-        ..., description="OCR client to use for image processing: 'none', 'openai', or 'azure'.",
+        ...,
+        description="OCR client to use for image processing: 'none', 'openai', or 'azure'.",
     ),
     metadata: Optional[List[str]] = Form([], description="Optional metadata tags."),
     split_params: str = Form(

--- a/src/reader/read_manager.py
+++ b/src/reader/read_manager.py
@@ -45,6 +45,9 @@ class ReadManager:
         Returns:
             str: Converted Markdown text.
         """
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(self.input_path, file_path)
+
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
         if os.path.getsize(file_path) == 0:
@@ -107,6 +110,7 @@ class ReadManager:
             "pptx": MarkItDownConverter(client, model),
             "pdf": MarkItDownConverter(client, model),
             "jpg": MarkItDownConverter(client, model),
+            "jpeg": MarkItDownConverter(client, model),
             "png": MarkItDownConverter(client, model),
         }
         return mapping.get(ext)


### PR DESCRIPTION
Fix CLI application when reading files from absolute path.

- Modify ReadManager to allow absolute paths.